### PR TITLE
Fix description of unist-util-select

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ A list of **VFile**-related utilities can be found at [**vfile**](https://github
     — `parent` references on nodes;
 
 *   [`unist-util-select`](https://github.com/eush77/unist-util-select)
-    — Visit direct children of a parent;
+    — Select nodes with CSS-like selectors;
 
 *   [`unist-util-visit`](https://github.com/wooorm/unist-util-visit)
     — Recursively walk over nodes;


### PR DESCRIPTION
It seems that the description was copied from [unist-util-visit-children](https://github.com/wooorm/unist-util-visit-children) but these are different packages.